### PR TITLE
Implement SDK_BaseController.ControllerElements.AttachPoint

### DIFF
--- a/EditorMotionControllerModel/Plugins/x64/MotionControllerModel.dll.meta
+++ b/EditorMotionControllerModel/Plugins/x64/MotionControllerModel.dll.meta
@@ -1,14 +1,15 @@
 fileFormatVersion: 2
 guid: a6c7973b2aeba9d48aec93a04f0fb3dc
-timeCreated: 1508792442
-licenseType: Pro
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
   iconMap: {}
   executionOrder: {}
+  defineConstraints: []
   isPreloaded: 0
   isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
   - first:
       '': Any
@@ -61,7 +62,7 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   - first:
       Standalone: LinuxUniversal
     second:

--- a/Extensions/MotionControllerInfo.cs
+++ b/Extensions/MotionControllerInfo.cs
@@ -28,6 +28,7 @@ namespace VRTK.WindowsMixedReality
         public readonly InteractionSourceHandedness Handedness;
 #endif
 
+        private GameObject trackingMesh;
         private GameObject home;
         private Transform homePressed;
         private Transform homeUnpressed;
@@ -61,6 +62,7 @@ namespace VRTK.WindowsMixedReality
         private GameObject touchpadTouchVisualizer;
         private GameObject pointingPose;
 
+        private string attachPointPath;
         private string homePath;
         private string selectPath;
         private string graspPath;
@@ -184,6 +186,9 @@ namespace VRTK.WindowsMixedReality
                 // visualizer.
                 switch (child.name.ToLower())
                 {
+                    case "tracking_mesh":
+                        trackingMesh = child.gameObject;
+                        break;
                     case "touch":
                         touchpadTouchVisualizer = MotionControllerVisualizer.Instance.SpawnTouchpadVisualizer(child);
                         break;
@@ -417,7 +422,7 @@ namespace VRTK.WindowsMixedReality
         private void CreatePathToTransform(Transform transform)
         {
             Transform parentTransform = transform.parent;
-            SDK_BaseController.ControllerElements controllerElement = SDK_BaseController.ControllerElements.AttachPoint;
+            SDK_BaseController.ControllerElements controllerElement = SDK_BaseController.ControllerElements.Body;
 
             string path = transform.name;
 
@@ -425,6 +430,9 @@ namespace VRTK.WindowsMixedReality
             {
                 switch (parentTransform.name.ToLower())
                 {
+                    case "tracking_mesh":
+                        controllerElement = SDK_BaseController.ControllerElements.AttachPoint;
+                        break;
                     case "home":
                         controllerElement = SDK_BaseController.ControllerElements.SystemMenu;
                         break;
@@ -452,6 +460,9 @@ namespace VRTK.WindowsMixedReality
 
             switch (controllerElement)
             {
+                case SDK_BaseController.ControllerElements.AttachPoint:
+                    attachPointPath = path;
+                    break;
                 case SDK_BaseController.ControllerElements.SystemMenu:
                     homePath = path;
                     break;
@@ -477,6 +488,8 @@ namespace VRTK.WindowsMixedReality
         {
             switch (button)
             {
+                case SDK_BaseController.ControllerElements.AttachPoint:
+                    return attachPointPath;
                 case SDK_BaseController.ControllerElements.SystemMenu:
                     return homePath;
                 case SDK_BaseController.ControllerElements.StartMenu:

--- a/GLTF/Plugins/GLTFSerialization/GLTFSerialization.dll.meta
+++ b/GLTF/Plugins/GLTFSerialization/GLTFSerialization.dll.meta
@@ -1,14 +1,15 @@
 fileFormatVersion: 2
 guid: 0913c98ce5c1cf342be8946be9e136dd
-timeCreated: 1520415760
-licenseType: Free
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
   iconMap: {}
   executionOrder: {}
+  defineConstraints: []
   isPreloaded: 0
   isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
   - first:
       '': Any
@@ -61,7 +62,7 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   - first:
       Standalone: LinuxUniversal
     second:

--- a/GLTF/Plugins/GLTFSerialization/WSA/GLTFSerializationUWP.dll.meta
+++ b/GLTF/Plugins/GLTFSerialization/WSA/GLTFSerializationUWP.dll.meta
@@ -1,14 +1,15 @@
 fileFormatVersion: 2
 guid: b3b6815897e7a714990c8210bf80e168
-timeCreated: 1520415826
-licenseType: Free
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
   iconMap: {}
   executionOrder: {}
+  defineConstraints: []
   isPreloaded: 0
   isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
   - first:
       '': Any
@@ -61,7 +62,7 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   - first:
       Standalone: LinuxUniversal
     second:

--- a/GLTF/Plugins/JsonNet/Newtonsoft.Json.dll.meta
+++ b/GLTF/Plugins/JsonNet/Newtonsoft.Json.dll.meta
@@ -1,14 +1,15 @@
 fileFormatVersion: 2
 guid: d35248feef80c524ba6900185e0137fd
-timeCreated: 1520415821
-licenseType: Free
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
   iconMap: {}
   executionOrder: {}
+  defineConstraints: []
   isPreloaded: 0
   isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
   - first:
       '': Any
@@ -61,7 +62,7 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   - first:
       Standalone: LinuxUniversal
     second:

--- a/GLTF/Plugins/JsonNet/WSA/Newtonsoft.Json.dll.meta
+++ b/GLTF/Plugins/JsonNet/WSA/Newtonsoft.Json.dll.meta
@@ -1,14 +1,15 @@
 fileFormatVersion: 2
 guid: 68c1f470b7a68cd489d18a2235963cf0
-timeCreated: 1520415876
-licenseType: Free
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
   iconMap: {}
   executionOrder: {}
+  defineConstraints: []
   isPreloaded: 0
   isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
   - first:
       '': Any
@@ -61,7 +62,7 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        CPU: x86_64
+        CPU: AnyCPU
   - first:
       Standalone: LinuxUniversal
     second:


### PR DESCRIPTION
This patch fixes #10 , which is caused by the missing AttachPoint in the controller model. In this patch, the AttachPoint is defined on the tracking mesh.

However, because the model is loaded only if the controller is present, errors will still appear until the controller is connected. The fix for these error messages is implemented for VRTK v3 in [this commit](https://github.com/w1ndy/VRTK/commit/aa5e29aa6cbeeb08a56dcb4359643cc3e4e177a6). However, currently there is no way to merge into the official repo given that v3 has stopped development.